### PR TITLE
fix handling MsgId header with 0x00

### DIFF
--- a/mqseries.c
+++ b/mqseries.c
@@ -1606,9 +1606,9 @@ PHP_FUNCTION(mqseries_bytes_val)
 
 	if (bytes && bytes->bytes) {
 #ifdef ZEND_ENGINE_3
-		RETVAL_STRING((char *) bytes->bytes);
+		RETVAL_STRINGL((char *) bytes->bytes, 24); /* MQBYTE24 */
 #else
-		RETVAL_STRING((char *) bytes->bytes, 1);
+		RETVAL_STRING((char *) bytes->bytes, 24, 1); /* MQBYTE24 */
 #endif
 	} else {
 		RETVAL_NULL();

--- a/mqseries_helper.c
+++ b/mqseries_helper.c
@@ -84,7 +84,9 @@ Author: Michael Bretterklieber <mbretter@jawa.at>
 				} \
 			} else if (Z_TYPE_P(tmp) != IS_NULL) { \
 				convert_to_string(tmp); \
-				strncpy((MQCHAR *) s->m, Z_STRVAL_P(tmp), sizeof(s->m)); \
+				char *tmp_val = Z_STRVAL_P(tmp); \
+				size_t i;  \
+				for (i = 0; i < sizeof(s->m); i++) s->m[i] = tmp_val[i]; \
 			} \
 		} \
 	} while(0)
@@ -888,7 +890,7 @@ void _mqseries_set_mqgmo_from_array(zval *array, PMQGMO get_msg_opts  TSRMLS_DC)
 #ifdef MQGMO_VERSION_3
 		case MQGMO_VERSION_3:
 			MQSERIES_SETOPT_LONG(get_msg_opts, ReturnedLength);
-			MQSERIES_SETOPT_RESBYTES(get_msg_opts, MsgToken);
+			MQSERIES_SETOPT_RESBYTES(get_msg_opts, MsgToken); 
 			// no break intentional
 #endif /* MQGMO_VERSION_3 */
 

--- a/mqseries_helper.c
+++ b/mqseries_helper.c
@@ -890,7 +890,7 @@ void _mqseries_set_mqgmo_from_array(zval *array, PMQGMO get_msg_opts  TSRMLS_DC)
 #ifdef MQGMO_VERSION_3
 		case MQGMO_VERSION_3:
 			MQSERIES_SETOPT_LONG(get_msg_opts, ReturnedLength);
-			MQSERIES_SETOPT_RESBYTES(get_msg_opts, MsgToken); 
+			MQSERIES_SETOPT_RESBYTES(get_msg_opts, MsgToken);
 			// no break intentional
 #endif /* MQGMO_VERSION_3 */
 


### PR DESCRIPTION
Review my workaround for this bug.

Example message for test:

```
$msgId = '414d5120514d544553543030312020205f5500962e17af43';
echo sprintf("Org MsgId: %s" . PHP_EOL, $msgId);
$correlId = '514d5120514d544553543030312020205f5500962e17af43';
echo sprintf("Org CorrelId: %s" . PHP_EOL, $correlId);
$groupId = '614d5120514d544553543030312020205f5500962e17af43';
echo sprintf("Org GroupId: %s" . PHP_EOL, $groupId);

$md = 	array(
		'Version' => MQSERIES_MQMD_VERSION_1,
		'Expiry' => MQSERIES_MQEI_UNLIMITED,
		'Report' => MQSERIES_MQRO_NONE,
		'MsgType' => MQSERIES_MQMT_DATAGRAM,
		'Format' => MQSERIES_MQFMT_STRING,
		'Priority' => 1,
		'Persistence' => MQSERIES_MQPER_PERSISTENT,
		'MsgId' => hex2bin($msgId),
		'CorrelId' => hex2bin($correlId),
		'GroupId' => hex2bin($groupId),
	);

$pmo = array('Options' => MQSERIES_MQPMO_NEW_MSG_ID);
$pmo = [];
mqseries_put(
	$conn, 
	$obj,
	$md,
	$pmo,
	'Ping',
	$comp_code,
	$reason);

```

